### PR TITLE
Add Handler for Create and corresponding UTs

### DIFF
--- a/deliverystream/src/main/java/com/amazonaws/kinesisfirehose/deliverystream/CallbackContext.java
+++ b/deliverystream/src/main/java/com/amazonaws/kinesisfirehose/deliverystream/CallbackContext.java
@@ -1,0 +1,15 @@
+package com.amazonaws.kinesisfirehose.deliverystream;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CallbackContext {
+	private Integer stabilizationRetriesRemaining;
+	private String deliveryStreamStatus;
+}

--- a/deliverystream/src/main/java/com/amazonaws/kinesisfirehose/deliverystream/Configuration.java
+++ b/deliverystream/src/main/java/com/amazonaws/kinesisfirehose/deliverystream/Configuration.java
@@ -1,0 +1,13 @@
+package com.amazonaws.kinesisfirehose.deliverystream;
+
+import java.util.Map;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
+class Configuration extends BaseConfiguration {
+
+    public Configuration() {
+        super("aws-kinesisfirehose-deliverystream.json");
+    }
+
+}

--- a/deliverystream/src/main/java/com/amazonaws/kinesisfirehose/deliverystream/CreateHandler.java
+++ b/deliverystream/src/main/java/com/amazonaws/kinesisfirehose/deliverystream/CreateHandler.java
@@ -1,0 +1,136 @@
+package com.amazonaws.kinesisfirehose.deliverystream;
+
+import com.amazonaws.util.StringUtils;
+import lombok.val;
+import software.amazon.awssdk.services.firehose.FirehoseClient;
+import software.amazon.awssdk.services.firehose.model.CreateDeliveryStreamRequest;
+import software.amazon.awssdk.services.firehose.model.DescribeDeliveryStreamRequest;
+import software.amazon.awssdk.services.firehose.model.DeliveryStreamStatus;
+import software.amazon.awssdk.services.firehose.model.ResourceInUseException;
+import software.amazon.awssdk.services.firehose.model.ResourceNotFoundException;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.resource.IdentifierUtils;
+
+import java.time.Duration;
+
+public class CreateHandler extends BaseHandler<CallbackContext> {
+    static final int NUMBER_OF_STATUS_POLL_RETRIES = 40;
+    static final String TIMED_OUT_MESSAGE = "Timed out waiting for the delivery stream to become ACTIVE.";
+
+    private AmazonWebServicesClientProxy clientProxy;
+    private final FirehoseClient firehoseClient = FirehoseClient.create();
+
+    @Override
+    public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+        final AmazonWebServicesClientProxy proxy,
+        final ResourceHandlerRequest<ResourceModel> request,
+        final CallbackContext callbackContext,
+        final Logger logger) {
+
+        final ResourceModel model = request.getDesiredResourceState();
+        clientProxy = proxy;
+
+        final CallbackContext currentContext = callbackContext == null
+                ? CallbackContext.builder()
+                .stabilizationRetriesRemaining(NUMBER_OF_STATUS_POLL_RETRIES)
+                .build()
+                : callbackContext;
+
+        if(callbackContext == null && doesDeliveryStreamExistWithName(model)) {
+            final Exception e = ResourceInUseException.builder()
+                    .message("Firehose already exists with the name: " + model.getDeliveryStreamName())
+                    .build();
+            return ProgressEvent.defaultFailureHandler(e, ExceptionMapper.mapToHandlerErrorCode(e));
+        }
+
+        if (StringUtils.isNullOrEmpty(model.getDeliveryStreamName())) {
+            model.setDeliveryStreamName(
+                    IdentifierUtils.generateResourceIdentifier(
+                            request.getLogicalResourceIdentifier(),
+                            request.getClientRequestToken()
+                    )
+            );
+        }
+
+        // This Lambda will continually be re-invoked with the current state of the instance, finally succeeding when state stabilizes.
+        return createDeliveryStreamAndUpdateProgress(model, currentContext);
+    }
+
+
+    private ProgressEvent<ResourceModel, CallbackContext> createDeliveryStreamAndUpdateProgress(ResourceModel model, CallbackContext callbackContext) {
+        val deliveryStreamStatus = callbackContext.getDeliveryStreamStatus();
+
+        if (callbackContext.getStabilizationRetriesRemaining() == 0) {
+            throw new RuntimeException(TIMED_OUT_MESSAGE);
+        }
+
+        if (deliveryStreamStatus == null) {
+            try {
+                return createDeliveryStream(model);
+            } catch (final Exception e) {
+                return ProgressEvent.defaultFailureHandler(e, ExceptionMapper.mapToHandlerErrorCode(e));
+            }
+        } else if (deliveryStreamStatus.equals(DeliveryStreamStatus.ACTIVE.toString())) {
+            return ProgressEvent.defaultSuccessHandler(model);
+        } else {
+            return ProgressEvent.defaultInProgressHandler(CallbackContext.builder()
+                    .deliveryStreamStatus(getDeliveryStreamStatus(model))
+                    .stabilizationRetriesRemaining(callbackContext.getStabilizationRetriesRemaining() - 1)
+                    .build(),
+                    (int)Duration.ofSeconds(30).getSeconds(),
+                    model);
+        }
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> createDeliveryStream(ResourceModel model) {
+        val createDeliveryStreamRequest = CreateDeliveryStreamRequest.builder()
+                .deliveryStreamName(model.getDeliveryStreamName())
+                .deliveryStreamType(model.getDeliveryStreamType())
+                .s3DestinationConfiguration(HandlerUtils.translateS3DestinationConfiguration(model.getS3DestinationConfiguration()))
+                .extendedS3DestinationConfiguration(HandlerUtils.translateExtendedS3DestinationConfiguration(model.getExtendedS3DestinationConfiguration()))
+                .redshiftDestinationConfiguration(HandlerUtils.translateRedshiftDestinationConfiguration(model.getRedshiftDestinationConfiguration()))
+                .elasticsearchDestinationConfiguration(HandlerUtils.translateElasticsearchDestinationConfiguration(model.getElasticsearchDestinationConfiguration()))
+                .kinesisStreamSourceConfiguration(HandlerUtils.translateKinesisStreamSourceConfiguration(model.getKinesisStreamSourceConfiguration()))
+                .splunkDestinationConfiguration(HandlerUtils.translateSplunkDestinationConfiguration(model.getSplunkDestinationConfiguration()))
+                .build();
+
+        //Firehose API returns an ARN on create, but does not accept ARN for any of its operations that act on a DeliveryStream
+        //This is why DeliveryStream name is the physical resource ID and not the ARN
+        val response = clientProxy.injectCredentialsAndInvokeV2(createDeliveryStreamRequest, firehoseClient::createDeliveryStream);
+        model.setId(model.getDeliveryStreamName());
+        model.setArn(response.deliveryStreamARN());
+        return ProgressEvent.defaultInProgressHandler(CallbackContext.builder()
+                .deliveryStreamStatus(getDeliveryStreamStatus(model))
+                .stabilizationRetriesRemaining(NUMBER_OF_STATUS_POLL_RETRIES)
+                .build(),
+                (int)Duration.ofSeconds(30).getSeconds(),
+                model);
+    }
+
+    private String getDeliveryStreamStatus(ResourceModel model) {
+        val response = clientProxy.injectCredentialsAndInvokeV2(DescribeDeliveryStreamRequest.builder()
+                .deliveryStreamName(model.getDeliveryStreamName())
+                .build(),
+                firehoseClient::describeDeliveryStream);
+        return response.deliveryStreamDescription().deliveryStreamStatusAsString();
+    }
+
+    private boolean doesDeliveryStreamExistWithName(ResourceModel model) {
+        if(StringUtils.isNullOrEmpty(model.getDeliveryStreamName())) {
+            return false;
+        }
+
+        try {
+            clientProxy.injectCredentialsAndInvokeV2(DescribeDeliveryStreamRequest.builder()
+                    .deliveryStreamName(model.getDeliveryStreamName())
+                    .build(),
+                    firehoseClient::describeDeliveryStream);
+            return true;
+        } catch (ResourceNotFoundException e) {
+            return false;
+        }
+    }
+}

--- a/deliverystream/src/main/java/com/amazonaws/kinesisfirehose/deliverystream/DeleteHandler.java
+++ b/deliverystream/src/main/java/com/amazonaws/kinesisfirehose/deliverystream/DeleteHandler.java
@@ -1,0 +1,27 @@
+package com.amazonaws.kinesisfirehose.deliverystream;
+
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+public class DeleteHandler extends BaseHandler<CallbackContext> {
+
+    @Override
+    public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+        final AmazonWebServicesClientProxy proxy,
+        final ResourceHandlerRequest<ResourceModel> request,
+        final CallbackContext callbackContext,
+        final Logger logger) {
+
+        final ResourceModel model = request.getDesiredResourceState();
+
+        // TODO : put code here
+
+        return ProgressEvent.<ResourceModel, CallbackContext>builder()
+            .resourceModel(model)
+            .status(OperationStatus.SUCCESS)
+            .build();
+    }
+}

--- a/deliverystream/src/main/java/com/amazonaws/kinesisfirehose/deliverystream/ExceptionMapper.java
+++ b/deliverystream/src/main/java/com/amazonaws/kinesisfirehose/deliverystream/ExceptionMapper.java
@@ -1,0 +1,38 @@
+package com.amazonaws.kinesisfirehose.deliverystream;
+
+import lombok.Builder;
+import software.amazon.awssdk.services.firehose.model.FirehoseException;
+import software.amazon.awssdk.services.firehose.model.InvalidArgumentException;
+import software.amazon.awssdk.services.firehose.model.InvalidKmsResourceException;
+import software.amazon.awssdk.services.firehose.model.LimitExceededException;
+import software.amazon.awssdk.services.firehose.model.ResourceInUseException;
+import software.amazon.awssdk.services.firehose.model.ResourceNotFoundException;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
+
+@Builder
+public final class ExceptionMapper {
+	private ExceptionMapper() {
+	}
+
+	/**
+	 * Translates the Network Manager's client exception to a Cfn Handler Error Code.
+	 * Ref: https://w.amazon.com/bin/view/AWS21/Design/Uluru/HandlerContract
+	 */
+	 static HandlerErrorCode mapToHandlerErrorCode(final Exception exception) {
+		if (exception instanceof ResourceInUseException) {
+			return HandlerErrorCode.ResourceConflict;
+		} else if (exception instanceof InvalidArgumentException) {
+			return HandlerErrorCode.InvalidRequest;
+		} else if (exception instanceof InvalidKmsResourceException) {
+			return HandlerErrorCode.InvalidRequest;
+		} else if (exception instanceof LimitExceededException) {
+			return HandlerErrorCode.ServiceLimitExceeded;
+		} else if (exception instanceof FirehoseException) {
+			return HandlerErrorCode.ServiceInternalError;
+		} else if (exception instanceof ResourceNotFoundException) {
+			return HandlerErrorCode.NotFound;
+		} else {
+			return HandlerErrorCode.InternalFailure;
+		}
+	}
+}

--- a/deliverystream/src/main/java/com/amazonaws/kinesisfirehose/deliverystream/HandlerUtils.java
+++ b/deliverystream/src/main/java/com/amazonaws/kinesisfirehose/deliverystream/HandlerUtils.java
@@ -1,0 +1,645 @@
+package com.amazonaws.kinesisfirehose.deliverystream;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Collections2;
+import software.amazon.awssdk.services.firehose.model.ElasticsearchDestinationUpdate;
+import software.amazon.awssdk.services.firehose.model.ExtendedS3DestinationUpdate;
+import software.amazon.awssdk.services.firehose.model.RedshiftDestinationUpdate;
+import software.amazon.awssdk.services.firehose.model.S3DestinationUpdate;
+import software.amazon.awssdk.services.firehose.model.SplunkDestinationUpdate;
+
+import java.util.Collection;
+
+class HandlerUtils {
+
+	static software.amazon.awssdk.services.firehose.model.KinesisStreamSourceConfiguration translateKinesisStreamSourceConfiguration(final KinesisStreamSourceConfiguration kinesisStreamSourceConfiguration) {
+		if(kinesisStreamSourceConfiguration == null) return null;
+		return software.amazon.awssdk.services.firehose.model.KinesisStreamSourceConfiguration.builder()
+				.kinesisStreamARN(kinesisStreamSourceConfiguration.getKinesisStreamARN())
+				.roleARN(kinesisStreamSourceConfiguration.getRoleARN())
+				.build();
+	}
+
+	public static Collection<software.amazon.awssdk.services.firehose.model.KinesisStreamSourceConfiguration> translateKinesisStreamSourceConfigurationCollection(final Collection<KinesisStreamSourceConfiguration> kinesisStreamSourceConfigurationCollection) {
+		if(kinesisStreamSourceConfigurationCollection == null) return null;
+		return Collections2.transform(kinesisStreamSourceConfigurationCollection, new Function<KinesisStreamSourceConfiguration, software.amazon.awssdk.services.firehose.model.KinesisStreamSourceConfiguration>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.KinesisStreamSourceConfiguration apply(final KinesisStreamSourceConfiguration input) {
+				return translateKinesisStreamSourceConfiguration(input);
+			}
+		});
+	}
+
+	/*public static software.amazon.awssdk.services.firehose.model.DeliveryStreamEncryptionConfigurationInput translateDeliveryStreamEncryptionConfigurationInput(final DeliveryStreamEncryptionConfigurationInput deliveryStreamEncryptionConfigurationInput) {
+		if(deliveryStreamEncryptionConfigurationInput == null) return null;
+		return software.amazon.awssdk.services.firehose.model.DeliveryStreamEncryptionConfigurationInput.builder()
+				.keyType(deliveryStreamEncryptionConfigurationInput.getKeyType())
+				.keyARN(deliveryStreamEncryptionConfigurationInput.getKeyARN())
+				.build();
+	}
+
+	public static Collection<software.amazon.awssdk.services.firehose.model.DeliveryStreamEncryptionConfigurationInput> translateDeliveryStreamEncryptionConfigurationInputCollection(final Collection<DeliveryStreamEncryptionConfigurationInput> deliveryStreamEncryptionConfigurationInputCollection) {
+		if(deliveryStreamEncryptionConfigurationInputCollection == null) return null;
+		return Collections2.transform(deliveryStreamEncryptionConfigurationInputCollection, new Function<DeliveryStreamEncryptionConfigurationInput, software.amazon.awssdk.services.firehose.model.DeliveryStreamEncryptionConfigurationInput>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.DeliveryStreamEncryptionConfigurationInput apply(final DeliveryStreamEncryptionConfigurationInput input) {
+				return translateDeliveryStreamEncryptionConfigurationInput(input);
+			}
+		});
+	}*/
+
+	static software.amazon.awssdk.services.firehose.model.S3DestinationConfiguration translateS3DestinationConfiguration(final S3DestinationConfiguration s3DestinationConfiguration) {
+		if(s3DestinationConfiguration == null) return null;
+		return software.amazon.awssdk.services.firehose.model.S3DestinationConfiguration.builder()
+				.bucketARN(s3DestinationConfiguration.getBucketARN())
+				.bufferingHints(translateBufferingHints(s3DestinationConfiguration.getBufferingHints()))
+				.cloudWatchLoggingOptions(translateCloudWatchLoggingOptions(s3DestinationConfiguration.getCloudWatchLoggingOptions()))
+				.compressionFormat(s3DestinationConfiguration.getCompressionFormat())
+				.encryptionConfiguration(translateEncryptionConfiguration(s3DestinationConfiguration.getEncryptionConfiguration()))
+				.prefix(s3DestinationConfiguration.getPrefix())
+				.roleARN(s3DestinationConfiguration.getRoleARN())
+				.errorOutputPrefix(s3DestinationConfiguration.getErrorOutputPrefix())
+				.build();
+	}
+
+	public static Collection<software.amazon.awssdk.services.firehose.model.S3DestinationConfiguration> translateS3DestinationConfigurationCollection(final Collection<S3DestinationConfiguration> s3DestinationConfigurationCollection) {
+		if(s3DestinationConfigurationCollection == null) return null;
+		return Collections2.transform(s3DestinationConfigurationCollection, new Function<S3DestinationConfiguration, software.amazon.awssdk.services.firehose.model.S3DestinationConfiguration>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.S3DestinationConfiguration apply(final S3DestinationConfiguration input) {
+				return translateS3DestinationConfiguration(input);
+			}
+		});
+	}
+
+	static software.amazon.awssdk.services.firehose.model.ExtendedS3DestinationConfiguration translateExtendedS3DestinationConfiguration(final ExtendedS3DestinationConfiguration extendedS3DestinationConfiguration) {
+		if(extendedS3DestinationConfiguration == null) return null;
+		return software.amazon.awssdk.services.firehose.model.ExtendedS3DestinationConfiguration.builder()
+				.bucketARN(extendedS3DestinationConfiguration.getBucketARN())
+				.bufferingHints(translateBufferingHints(extendedS3DestinationConfiguration.getBufferingHints()))
+				.cloudWatchLoggingOptions(translateCloudWatchLoggingOptions(extendedS3DestinationConfiguration.getCloudWatchLoggingOptions()))
+				.compressionFormat(extendedS3DestinationConfiguration.getCompressionFormat())
+				.encryptionConfiguration(translateEncryptionConfiguration(extendedS3DestinationConfiguration.getEncryptionConfiguration()))
+				.prefix(extendedS3DestinationConfiguration.getPrefix())
+				.roleARN(extendedS3DestinationConfiguration.getRoleARN())
+				.processingConfiguration(translateProcessingConfiguration(extendedS3DestinationConfiguration.getProcessingConfiguration()))
+				.s3BackupConfiguration(translateS3DestinationConfiguration(extendedS3DestinationConfiguration.getS3BackupConfiguration()))
+				.s3BackupMode(extendedS3DestinationConfiguration.getS3BackupMode())
+				.errorOutputPrefix(extendedS3DestinationConfiguration.getErrorOutputPrefix())
+				.dataFormatConversionConfiguration(translateDataFormatConversionConfiguration(extendedS3DestinationConfiguration.getDataFormatConversionConfiguration()))
+				.build();
+	}
+
+	 static Collection<software.amazon.awssdk.services.firehose.model.ExtendedS3DestinationConfiguration> translateExtendedS3DestinationConfigurationCollection(final Collection<ExtendedS3DestinationConfiguration> extendedS3DestinationConfigurationCollection) {
+		if(extendedS3DestinationConfigurationCollection == null) return null;
+		return Collections2.transform(extendedS3DestinationConfigurationCollection, new Function<ExtendedS3DestinationConfiguration, software.amazon.awssdk.services.firehose.model.ExtendedS3DestinationConfiguration>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.ExtendedS3DestinationConfiguration apply(final ExtendedS3DestinationConfiguration input) {
+				return translateExtendedS3DestinationConfiguration(input);
+			}
+		});
+	}
+
+	static software.amazon.awssdk.services.firehose.model.BufferingHints translateBufferingHints(final BufferingHints bufferingHints) {
+		if(bufferingHints == null) return null;
+		return software.amazon.awssdk.services.firehose.model.BufferingHints.builder()
+				.intervalInSeconds(bufferingHints.getIntervalInSeconds())
+				.sizeInMBs(bufferingHints.getSizeInMBs())
+				.build();
+	}
+
+	static Collection<software.amazon.awssdk.services.firehose.model.BufferingHints> translateBufferingHintsCollection(final Collection<BufferingHints> bufferingHintsCollection) {
+		if(bufferingHintsCollection == null) return null;
+		return Collections2.transform(bufferingHintsCollection, new Function<BufferingHints, software.amazon.awssdk.services.firehose.model.BufferingHints>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.BufferingHints apply(final BufferingHints input) {
+				return translateBufferingHints(input);
+			}
+		});
+	}
+
+	 static software.amazon.awssdk.services.firehose.model.EncryptionConfiguration translateEncryptionConfiguration(final EncryptionConfiguration encryptionConfiguration) {
+		if(encryptionConfiguration == null) return null;
+		return software.amazon.awssdk.services.firehose.model.EncryptionConfiguration.builder()
+				.kmsEncryptionConfig(translateKMSEncryptionConfig(encryptionConfiguration.getKMSEncryptionConfig()))
+				.noEncryptionConfig(encryptionConfiguration.getNoEncryptionConfig())
+				.build();
+	}
+
+	 static Collection<software.amazon.awssdk.services.firehose.model.EncryptionConfiguration> translateEncryptionConfigurationCollection(final Collection<EncryptionConfiguration> encryptionConfigurationCollection) {
+		if(encryptionConfigurationCollection == null) return null;
+		return Collections2.transform(encryptionConfigurationCollection, new Function<EncryptionConfiguration, software.amazon.awssdk.services.firehose.model.EncryptionConfiguration>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.EncryptionConfiguration apply(final EncryptionConfiguration input) {
+				return translateEncryptionConfiguration(input);
+			}
+		});
+	}
+
+	 static software.amazon.awssdk.services.firehose.model.KMSEncryptionConfig translateKMSEncryptionConfig(final KMSEncryptionConfig kMSEncryptionConfig) {
+		if(kMSEncryptionConfig == null) return null;
+		return software.amazon.awssdk.services.firehose.model.KMSEncryptionConfig.builder()
+				.awskmsKeyARN(kMSEncryptionConfig.getAWSKMSKeyARN())
+				.build();
+	}
+
+	 static Collection<software.amazon.awssdk.services.firehose.model.KMSEncryptionConfig> translateKMSEncryptionConfigCollection(final Collection<KMSEncryptionConfig> kMSEncryptionConfigCollection) {
+		if(kMSEncryptionConfigCollection == null) return null;
+		return Collections2.transform(kMSEncryptionConfigCollection, new Function<KMSEncryptionConfig, software.amazon.awssdk.services.firehose.model.KMSEncryptionConfig>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.KMSEncryptionConfig apply(final KMSEncryptionConfig input) {
+				return translateKMSEncryptionConfig(input);
+			}
+		});
+	}
+
+	 static software.amazon.awssdk.services.firehose.model.CloudWatchLoggingOptions translateCloudWatchLoggingOptions(final CloudWatchLoggingOptions cloudWatchLoggingOptions) {
+		if(cloudWatchLoggingOptions == null) return null;
+		return software.amazon.awssdk.services.firehose.model.CloudWatchLoggingOptions.builder()
+				.enabled(cloudWatchLoggingOptions.getEnabled())
+				.logGroupName(cloudWatchLoggingOptions.getLogGroupName())
+				.logStreamName(cloudWatchLoggingOptions.getLogStreamName())
+				.build();
+	}
+
+	 static Collection<software.amazon.awssdk.services.firehose.model.CloudWatchLoggingOptions> translateCloudWatchLoggingOptionsCollection(final Collection<CloudWatchLoggingOptions> cloudWatchLoggingOptionsCollection) {
+		if(cloudWatchLoggingOptionsCollection == null) return null;
+		return Collections2.transform(cloudWatchLoggingOptionsCollection, new Function<CloudWatchLoggingOptions, software.amazon.awssdk.services.firehose.model.CloudWatchLoggingOptions>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.CloudWatchLoggingOptions apply(final CloudWatchLoggingOptions input) {
+				return translateCloudWatchLoggingOptions(input);
+			}
+		});
+	}
+
+	 static software.amazon.awssdk.services.firehose.model.RedshiftDestinationConfiguration translateRedshiftDestinationConfiguration(final RedshiftDestinationConfiguration redshiftDestinationConfiguration) {
+		if(redshiftDestinationConfiguration == null) return null;
+		return software.amazon.awssdk.services.firehose.model.RedshiftDestinationConfiguration.builder()
+				.cloudWatchLoggingOptions(translateCloudWatchLoggingOptions(redshiftDestinationConfiguration.getCloudWatchLoggingOptions()))
+				.clusterJDBCURL(redshiftDestinationConfiguration.getClusterJDBCURL())
+				.copyCommand(translateCopyCommand(redshiftDestinationConfiguration.getCopyCommand()))
+				.password(redshiftDestinationConfiguration.getPassword())
+				.processingConfiguration(translateProcessingConfiguration(redshiftDestinationConfiguration.getProcessingConfiguration()))
+				.roleARN(redshiftDestinationConfiguration.getRoleARN())
+				.s3Configuration(translateS3DestinationConfiguration(redshiftDestinationConfiguration.getS3Configuration()))
+				.username(redshiftDestinationConfiguration.getUsername())
+				.build();
+	}
+
+	 static Collection<software.amazon.awssdk.services.firehose.model.RedshiftDestinationConfiguration> translateRedshiftDestinationConfigurationCollection(final Collection<RedshiftDestinationConfiguration> redshiftDestinationConfigurationCollection) {
+		if(redshiftDestinationConfigurationCollection == null) return null;
+		return Collections2.transform(redshiftDestinationConfigurationCollection, new Function<RedshiftDestinationConfiguration, software.amazon.awssdk.services.firehose.model.RedshiftDestinationConfiguration>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.RedshiftDestinationConfiguration apply(final RedshiftDestinationConfiguration input) {
+				return translateRedshiftDestinationConfiguration(input);
+			}
+		});
+	}
+
+	 static software.amazon.awssdk.services.firehose.model.CopyCommand translateCopyCommand(final CopyCommand copyCommand) {
+		if(copyCommand == null) return null;
+		return software.amazon.awssdk.services.firehose.model.CopyCommand.builder()
+				.copyOptions(copyCommand.getCopyOptions())
+				.dataTableColumns(copyCommand.getDataTableColumns())
+				.dataTableName(copyCommand.getDataTableName())
+				.build();
+	}
+
+	 static Collection<software.amazon.awssdk.services.firehose.model.CopyCommand> translateCopyCommandCollection(final Collection<CopyCommand> copyCommandCollection) {
+		if(copyCommandCollection == null) return null;
+		return Collections2.transform(copyCommandCollection, new Function<CopyCommand, software.amazon.awssdk.services.firehose.model.CopyCommand>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.CopyCommand apply(final CopyCommand input) {
+				return translateCopyCommand(input);
+			}
+		});
+	}
+
+	 static software.amazon.awssdk.services.firehose.model.ElasticsearchDestinationConfiguration translateElasticsearchDestinationConfiguration(final ElasticsearchDestinationConfiguration elasticsearchDestinationConfiguration) {
+		if(elasticsearchDestinationConfiguration == null) return null;
+		return software.amazon.awssdk.services.firehose.model.ElasticsearchDestinationConfiguration.builder()
+				.bufferingHints(translateElasticsearchBufferingHints(elasticsearchDestinationConfiguration.getBufferingHints()))
+				.cloudWatchLoggingOptions(translateCloudWatchLoggingOptions(elasticsearchDestinationConfiguration.getCloudWatchLoggingOptions()))
+				.domainARN(elasticsearchDestinationConfiguration.getDomainARN())
+				.indexName(elasticsearchDestinationConfiguration.getIndexName())
+				.indexRotationPeriod(elasticsearchDestinationConfiguration.getIndexRotationPeriod())
+				.processingConfiguration(translateProcessingConfiguration(elasticsearchDestinationConfiguration.getProcessingConfiguration()))
+				.retryOptions(translateElasticsearchRetryOptions(elasticsearchDestinationConfiguration.getRetryOptions()))
+				.roleARN(elasticsearchDestinationConfiguration.getRoleARN())
+				.s3BackupMode(elasticsearchDestinationConfiguration.getS3BackupMode())
+				.s3Configuration(translateS3DestinationConfiguration(elasticsearchDestinationConfiguration.getS3Configuration()))
+				.clusterEndpoint(elasticsearchDestinationConfiguration.getClusterEndpoint())
+				.build();
+	}
+
+	 static Collection<software.amazon.awssdk.services.firehose.model.ElasticsearchDestinationConfiguration> translateElasticsearchDestinationConfigurationCollection(final Collection<ElasticsearchDestinationConfiguration> elasticsearchDestinationConfigurationCollection) {
+		if(elasticsearchDestinationConfigurationCollection == null) return null;
+		return Collections2.transform(elasticsearchDestinationConfigurationCollection, new Function<ElasticsearchDestinationConfiguration, software.amazon.awssdk.services.firehose.model.ElasticsearchDestinationConfiguration>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.ElasticsearchDestinationConfiguration apply(final ElasticsearchDestinationConfiguration input) {
+				return translateElasticsearchDestinationConfiguration(input);
+			}
+		});
+	}
+
+	 static software.amazon.awssdk.services.firehose.model.ElasticsearchBufferingHints translateElasticsearchBufferingHints(final ElasticsearchBufferingHints elasticsearchBufferingHints) {
+		if(elasticsearchBufferingHints == null) return null;
+		return software.amazon.awssdk.services.firehose.model.ElasticsearchBufferingHints.builder()
+				.intervalInSeconds(elasticsearchBufferingHints.getIntervalInSeconds())
+				.sizeInMBs(elasticsearchBufferingHints.getSizeInMBs())
+				.build();
+	}
+
+	 static Collection<software.amazon.awssdk.services.firehose.model.ElasticsearchBufferingHints> translateElasticsearchBufferingHintsCollection(final Collection<ElasticsearchBufferingHints> elasticsearchBufferingHintsCollection) {
+		if(elasticsearchBufferingHintsCollection == null) return null;
+		return Collections2.transform(elasticsearchBufferingHintsCollection, new Function<ElasticsearchBufferingHints, software.amazon.awssdk.services.firehose.model.ElasticsearchBufferingHints>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.ElasticsearchBufferingHints apply(final ElasticsearchBufferingHints input) {
+				return translateElasticsearchBufferingHints(input);
+			}
+		});
+	}
+
+	 static software.amazon.awssdk.services.firehose.model.ElasticsearchRetryOptions translateElasticsearchRetryOptions(final ElasticsearchRetryOptions elasticsearchRetryOptions) {
+		if(elasticsearchRetryOptions == null) return null;
+		return software.amazon.awssdk.services.firehose.model.ElasticsearchRetryOptions.builder()
+				.durationInSeconds(elasticsearchRetryOptions.getDurationInSeconds())
+				.build();
+	}
+
+	 static Collection<software.amazon.awssdk.services.firehose.model.ElasticsearchRetryOptions> translateElasticsearchRetryOptionsCollection(final Collection<ElasticsearchRetryOptions> elasticsearchRetryOptionsCollection) {
+		if(elasticsearchRetryOptionsCollection == null) return null;
+		return Collections2.transform(elasticsearchRetryOptionsCollection, new Function<ElasticsearchRetryOptions, software.amazon.awssdk.services.firehose.model.ElasticsearchRetryOptions>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.ElasticsearchRetryOptions apply(final ElasticsearchRetryOptions input) {
+				return translateElasticsearchRetryOptions(input);
+			}
+		});
+	}
+
+	 static software.amazon.awssdk.services.firehose.model.ProcessingConfiguration translateProcessingConfiguration(final ProcessingConfiguration processingConfiguration) {
+		if(processingConfiguration == null) return null;
+		return software.amazon.awssdk.services.firehose.model.ProcessingConfiguration.builder()
+				.enabled(processingConfiguration.getEnabled())
+				.processors(translateProcessorCollection(processingConfiguration.getProcessors()))
+				.build();
+	}
+
+	 static Collection<software.amazon.awssdk.services.firehose.model.ProcessingConfiguration> translateProcessingConfigurationCollection(final Collection<ProcessingConfiguration> processingConfigurationCollection) {
+		if(processingConfigurationCollection == null) return null;
+		return Collections2.transform(processingConfigurationCollection, new Function<ProcessingConfiguration, software.amazon.awssdk.services.firehose.model.ProcessingConfiguration>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.ProcessingConfiguration apply(final ProcessingConfiguration input) {
+				return translateProcessingConfiguration(input);
+			}
+		});
+	}
+
+	 static software.amazon.awssdk.services.firehose.model.Processor translateProcessor(final Processor processor) {
+		if(processor == null) return null;
+		return software.amazon.awssdk.services.firehose.model.Processor.builder()
+				.parameters(translateProcessorParameterCollection(processor.getParameters()))
+				.type(processor.getType())
+				.build();
+	}
+
+	 static Collection<software.amazon.awssdk.services.firehose.model.Processor> translateProcessorCollection(final Collection<Processor> processorCollection) {
+		if(processorCollection == null) return null;
+		return Collections2.transform(processorCollection, new Function<Processor, software.amazon.awssdk.services.firehose.model.Processor>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.Processor apply(final Processor input) {
+				return translateProcessor(input);
+			}
+		});
+	}
+
+	 static software.amazon.awssdk.services.firehose.model.ProcessorParameter translateProcessorParameter(final ProcessorParameter processorParameter) {
+		if(processorParameter == null) return null;
+		return software.amazon.awssdk.services.firehose.model.ProcessorParameter.builder()
+				.parameterName(processorParameter.getParameterName())
+				.parameterValue(processorParameter.getParameterValue())
+				.build();
+	}
+
+	 static Collection<software.amazon.awssdk.services.firehose.model.ProcessorParameter> translateProcessorParameterCollection(final Collection<ProcessorParameter> processorParameterCollection) {
+		if(processorParameterCollection == null) return null;
+		return Collections2.transform(processorParameterCollection, new Function<ProcessorParameter, software.amazon.awssdk.services.firehose.model.ProcessorParameter>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.ProcessorParameter apply(final ProcessorParameter input) {
+				return translateProcessorParameter(input);
+			}
+		});
+	}
+
+	 static software.amazon.awssdk.services.firehose.model.DataFormatConversionConfiguration translateDataFormatConversionConfiguration(final DataFormatConversionConfiguration dataFormatConversionConfiguration) {
+		if(dataFormatConversionConfiguration == null) return null;
+		return software.amazon.awssdk.services.firehose.model.DataFormatConversionConfiguration.builder()
+				.schemaConfiguration(translateSchemaConfiguration(dataFormatConversionConfiguration.getSchemaConfiguration()))
+				.inputFormatConfiguration(translateInputFormatConfiguration(dataFormatConversionConfiguration.getInputFormatConfiguration()))
+				.outputFormatConfiguration(translateOutputFormatConfiguration(dataFormatConversionConfiguration.getOutputFormatConfiguration()))
+				.enabled(dataFormatConversionConfiguration.getEnabled())
+				.build();
+	}
+
+	 static Collection<software.amazon.awssdk.services.firehose.model.DataFormatConversionConfiguration> translateDataFormatConversionConfigurationCollection(final Collection<DataFormatConversionConfiguration> dataFormatConversionConfigurationCollection) {
+		if(dataFormatConversionConfigurationCollection == null) return null;
+		return Collections2.transform(dataFormatConversionConfigurationCollection, new Function<DataFormatConversionConfiguration, software.amazon.awssdk.services.firehose.model.DataFormatConversionConfiguration>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.DataFormatConversionConfiguration apply(final DataFormatConversionConfiguration input) {
+				return translateDataFormatConversionConfiguration(input);
+			}
+		});
+	}
+
+	 static software.amazon.awssdk.services.firehose.model.SchemaConfiguration translateSchemaConfiguration(final SchemaConfiguration schemaConfiguration) {
+		if(schemaConfiguration == null) return null;
+		return software.amazon.awssdk.services.firehose.model.SchemaConfiguration.builder()
+				.roleARN(schemaConfiguration.getRoleARN())
+				.catalogId(schemaConfiguration.getCatalogId())
+				.databaseName(schemaConfiguration.getDatabaseName())
+				.tableName(schemaConfiguration.getTableName())
+				.region(schemaConfiguration.getRegion())
+				.versionId(schemaConfiguration.getVersionId())
+				.build();
+	}
+
+	 static Collection<software.amazon.awssdk.services.firehose.model.SchemaConfiguration> translateSchemaConfigurationCollection(final Collection<SchemaConfiguration> schemaConfigurationCollection) {
+		if(schemaConfigurationCollection == null) return null;
+		return Collections2.transform(schemaConfigurationCollection, new Function<SchemaConfiguration, software.amazon.awssdk.services.firehose.model.SchemaConfiguration>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.SchemaConfiguration apply(final SchemaConfiguration input) {
+				return translateSchemaConfiguration(input);
+			}
+		});
+	}
+
+	 static software.amazon.awssdk.services.firehose.model.InputFormatConfiguration translateInputFormatConfiguration(final InputFormatConfiguration inputFormatConfiguration) {
+		if(inputFormatConfiguration == null) return null;
+		return software.amazon.awssdk.services.firehose.model.InputFormatConfiguration.builder()
+				.deserializer(translateDeserializer(inputFormatConfiguration.getDeserializer()))
+				.build();
+	}
+
+	 static Collection<software.amazon.awssdk.services.firehose.model.InputFormatConfiguration> translateInputFormatConfigurationCollection(final Collection<InputFormatConfiguration> inputFormatConfigurationCollection) {
+		if(inputFormatConfigurationCollection == null) return null;
+		return Collections2.transform(inputFormatConfigurationCollection, new Function<InputFormatConfiguration, software.amazon.awssdk.services.firehose.model.InputFormatConfiguration>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.InputFormatConfiguration apply(final InputFormatConfiguration input) {
+				return translateInputFormatConfiguration(input);
+			}
+		});
+	}
+
+	 static software.amazon.awssdk.services.firehose.model.Deserializer translateDeserializer(final Deserializer deserializer) {
+		if(deserializer == null) return null;
+		return software.amazon.awssdk.services.firehose.model.Deserializer.builder()
+				.openXJsonSerDe(translateOpenXJsonSerDe(deserializer.getOpenXJsonSerDe()))
+				.hiveJsonSerDe(translateHiveJsonSerDe(deserializer.getHiveJsonSerDe()))
+				.build();
+	}
+
+	 static Collection<software.amazon.awssdk.services.firehose.model.Deserializer> translateDeserializerCollection(final Collection<Deserializer> deserializerCollection) {
+		if(deserializerCollection == null) return null;
+		return Collections2.transform(deserializerCollection, new Function<Deserializer, software.amazon.awssdk.services.firehose.model.Deserializer>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.Deserializer apply(final Deserializer input) {
+				return translateDeserializer(input);
+			}
+		});
+	}
+
+	 static software.amazon.awssdk.services.firehose.model.OutputFormatConfiguration translateOutputFormatConfiguration(final OutputFormatConfiguration outputFormatConfiguration) {
+		if(outputFormatConfiguration == null) return null;
+		return software.amazon.awssdk.services.firehose.model.OutputFormatConfiguration.builder()
+				.serializer(translateSerializer(outputFormatConfiguration.getSerializer()))
+				.build();
+	}
+
+	 static Collection<software.amazon.awssdk.services.firehose.model.OutputFormatConfiguration> translateOutputFormatConfigurationCollection(final Collection<OutputFormatConfiguration> outputFormatConfigurationCollection) {
+		if(outputFormatConfigurationCollection == null) return null;
+		return Collections2.transform(outputFormatConfigurationCollection, new Function<OutputFormatConfiguration, software.amazon.awssdk.services.firehose.model.OutputFormatConfiguration>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.OutputFormatConfiguration apply(final OutputFormatConfiguration input) {
+				return translateOutputFormatConfiguration(input);
+			}
+		});
+	}
+
+	 static software.amazon.awssdk.services.firehose.model.Serializer translateSerializer(final Serializer serializer) {
+		if(serializer == null) return null;
+		return software.amazon.awssdk.services.firehose.model.Serializer.builder()
+				.parquetSerDe(translateParquetSerDe(serializer.getParquetSerDe()))
+				.orcSerDe(translateOrcSerDe(serializer.getOrcSerDe()))
+				.build();
+	}
+
+	 static Collection<software.amazon.awssdk.services.firehose.model.Serializer> translateSerializerCollection(final Collection<Serializer> serializerCollection) {
+		if(serializerCollection == null) return null;
+		return Collections2.transform(serializerCollection, new Function<Serializer, software.amazon.awssdk.services.firehose.model.Serializer>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.Serializer apply(final Serializer input) {
+				return translateSerializer(input);
+			}
+		});
+	}
+
+	 static software.amazon.awssdk.services.firehose.model.OpenXJsonSerDe translateOpenXJsonSerDe(final OpenXJsonSerDe openXJsonSerDe) {
+		if(openXJsonSerDe == null) return null;
+		return software.amazon.awssdk.services.firehose.model.OpenXJsonSerDe.builder()
+				.convertDotsInJsonKeysToUnderscores(openXJsonSerDe.getConvertDotsInJsonKeysToUnderscores())
+				.caseInsensitive(openXJsonSerDe.getCaseInsensitive())
+				.columnToJsonKeyMappings(openXJsonSerDe.getColumnToJsonKeyMappings())
+				.build();
+	}
+
+	 static Collection<software.amazon.awssdk.services.firehose.model.OpenXJsonSerDe> translateOpenXJsonSerDeCollection(final Collection<OpenXJsonSerDe> openXJsonSerDeCollection) {
+		if(openXJsonSerDeCollection == null) return null;
+		return Collections2.transform(openXJsonSerDeCollection, new Function<OpenXJsonSerDe, software.amazon.awssdk.services.firehose.model.OpenXJsonSerDe>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.OpenXJsonSerDe apply(final OpenXJsonSerDe input) {
+				return translateOpenXJsonSerDe(input);
+			}
+		});
+	}
+
+	 static software.amazon.awssdk.services.firehose.model.HiveJsonSerDe translateHiveJsonSerDe(final HiveJsonSerDe hiveJsonSerDe) {
+		if(hiveJsonSerDe == null) return null;
+		return software.amazon.awssdk.services.firehose.model.HiveJsonSerDe.builder()
+				.timestampFormats(hiveJsonSerDe.getTimestampFormats())
+				.build();
+	}
+
+	 static Collection<software.amazon.awssdk.services.firehose.model.HiveJsonSerDe> translateHiveJsonSerDeCollection(final Collection<HiveJsonSerDe> hiveJsonSerDeCollection) {
+		if(hiveJsonSerDeCollection == null) return null;
+		return Collections2.transform(hiveJsonSerDeCollection, new Function<HiveJsonSerDe, software.amazon.awssdk.services.firehose.model.HiveJsonSerDe>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.HiveJsonSerDe apply(final HiveJsonSerDe input) {
+				return translateHiveJsonSerDe(input);
+			}
+		});
+	}
+
+	 static software.amazon.awssdk.services.firehose.model.ParquetSerDe translateParquetSerDe(final ParquetSerDe parquetSerDe) {
+		if(parquetSerDe == null) return null;
+		return software.amazon.awssdk.services.firehose.model.ParquetSerDe.builder()
+				.blockSizeBytes(parquetSerDe.getBlockSizeBytes())
+				.pageSizeBytes(parquetSerDe.getPageSizeBytes())
+				.compression(parquetSerDe.getCompression())
+				.enableDictionaryCompression(parquetSerDe.getEnableDictionaryCompression())
+				.maxPaddingBytes(parquetSerDe.getMaxPaddingBytes())
+				.writerVersion(parquetSerDe.getWriterVersion())
+				.build();
+	}
+
+	 static Collection<software.amazon.awssdk.services.firehose.model.ParquetSerDe> translateParquetSerDeCollection(final Collection<ParquetSerDe> parquetSerDeCollection) {
+		if(parquetSerDeCollection == null) return null;
+		return Collections2.transform(parquetSerDeCollection, new Function<ParquetSerDe, software.amazon.awssdk.services.firehose.model.ParquetSerDe>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.ParquetSerDe apply(final ParquetSerDe input) {
+				return translateParquetSerDe(input);
+			}
+		});
+	}
+
+	 static software.amazon.awssdk.services.firehose.model.OrcSerDe translateOrcSerDe(final OrcSerDe orcSerDe) {
+		if(orcSerDe == null) return null;
+		return software.amazon.awssdk.services.firehose.model.OrcSerDe.builder()
+				.stripeSizeBytes(orcSerDe.getStripeSizeBytes())
+				.blockSizeBytes(orcSerDe.getBlockSizeBytes())
+				.rowIndexStride(orcSerDe.getRowIndexStride())
+				.enablePadding(orcSerDe.getEnablePadding())
+				.paddingTolerance(orcSerDe.getPaddingTolerance())
+				.compression(orcSerDe.getCompression())
+				.bloomFilterColumns(orcSerDe.getBloomFilterColumns())
+				.bloomFilterFalsePositiveProbability(orcSerDe.getBloomFilterFalsePositiveProbability())
+				.dictionaryKeyThreshold(orcSerDe.getDictionaryKeyThreshold())
+				.formatVersion(orcSerDe.getFormatVersion())
+				.build();
+	}
+
+	 static Collection<software.amazon.awssdk.services.firehose.model.OrcSerDe> translateOrcSerDeCollection(final Collection<OrcSerDe> orcSerDeCollection) {
+		if(orcSerDeCollection == null) return null;
+		return Collections2.transform(orcSerDeCollection, new Function<OrcSerDe, software.amazon.awssdk.services.firehose.model.OrcSerDe>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.OrcSerDe apply(final OrcSerDe input) {
+				return translateOrcSerDe(input);
+			}
+		});
+	}
+
+	 static software.amazon.awssdk.services.firehose.model.SplunkDestinationConfiguration translateSplunkDestinationConfiguration(final SplunkDestinationConfiguration splunkDestinationConfiguration) {
+		if(splunkDestinationConfiguration == null) return null;
+		return software.amazon.awssdk.services.firehose.model.SplunkDestinationConfiguration.builder()
+				.cloudWatchLoggingOptions(translateCloudWatchLoggingOptions(splunkDestinationConfiguration.getCloudWatchLoggingOptions()))
+				.hecAcknowledgmentTimeoutInSeconds(splunkDestinationConfiguration.getHECAcknowledgmentTimeoutInSeconds())
+				.hecEndpoint(splunkDestinationConfiguration.getHECEndpoint())
+				.hecEndpointType(splunkDestinationConfiguration.getHECEndpointType())
+				.hecToken(splunkDestinationConfiguration.getHECToken())
+				.processingConfiguration(translateProcessingConfiguration(splunkDestinationConfiguration.getProcessingConfiguration()))
+				.retryOptions(translateSplunkRetryOptions(splunkDestinationConfiguration.getRetryOptions()))
+				.s3BackupMode(splunkDestinationConfiguration.getS3BackupMode())
+				.s3Configuration(translateS3DestinationConfiguration(splunkDestinationConfiguration.getS3Configuration()))
+				.build();
+	}
+
+	 static Collection<software.amazon.awssdk.services.firehose.model.SplunkDestinationConfiguration> translateSplunkDestinationConfigurationCollection(final Collection<SplunkDestinationConfiguration> splunkDestinationConfigurationCollection) {
+		if(splunkDestinationConfigurationCollection == null) return null;
+		return Collections2.transform(splunkDestinationConfigurationCollection, new Function<SplunkDestinationConfiguration, software.amazon.awssdk.services.firehose.model.SplunkDestinationConfiguration>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.SplunkDestinationConfiguration apply(final SplunkDestinationConfiguration input) {
+				return translateSplunkDestinationConfiguration(input);
+			}
+		});
+	}
+
+	 static software.amazon.awssdk.services.firehose.model.SplunkRetryOptions translateSplunkRetryOptions(final SplunkRetryOptions splunkRetryOptions) {
+		if(splunkRetryOptions == null) return null;
+		return software.amazon.awssdk.services.firehose.model.SplunkRetryOptions.builder()
+				.durationInSeconds(splunkRetryOptions.getDurationInSeconds())
+				.build();
+	}
+
+	 static Collection<software.amazon.awssdk.services.firehose.model.SplunkRetryOptions> translateSplunkRetryOptionsCollection(final Collection<SplunkRetryOptions> splunkRetryOptionsCollection) {
+		if(splunkRetryOptionsCollection == null) return null;
+		return Collections2.transform(splunkRetryOptionsCollection, new Function<SplunkRetryOptions, software.amazon.awssdk.services.firehose.model.SplunkRetryOptions>() {
+			@Override
+			public software.amazon.awssdk.services.firehose.model.SplunkRetryOptions apply(final SplunkRetryOptions input) {
+				return translateSplunkRetryOptions(input);
+			}
+		});
+	}
+
+	static S3DestinationUpdate translateS3DestinationUpdate(final S3DestinationConfiguration s3DestinationConfiguration) {
+		if(s3DestinationConfiguration == null) return null;
+		return S3DestinationUpdate.builder()
+				.roleARN(s3DestinationConfiguration.getRoleARN())
+				.bucketARN(s3DestinationConfiguration.getBucketARN())
+				.prefix(s3DestinationConfiguration.getPrefix())
+				.bufferingHints(translateBufferingHints(s3DestinationConfiguration.getBufferingHints()))
+				.compressionFormat(s3DestinationConfiguration.getCompressionFormat())
+				.encryptionConfiguration(translateEncryptionConfiguration(s3DestinationConfiguration.getEncryptionConfiguration()))
+				.cloudWatchLoggingOptions(translateCloudWatchLoggingOptions(s3DestinationConfiguration.getCloudWatchLoggingOptions()))
+				.errorOutputPrefix(s3DestinationConfiguration.getErrorOutputPrefix())
+				.build();
+	}
+
+	static ExtendedS3DestinationUpdate translateExtendedS3DestinationUpdate (final ExtendedS3DestinationConfiguration extendedS3DestinationUpdate) {
+		if(extendedS3DestinationUpdate == null) return null;
+		return ExtendedS3DestinationUpdate.builder()
+				.bucketARN(extendedS3DestinationUpdate.getBucketARN())
+				.bufferingHints(translateBufferingHints(extendedS3DestinationUpdate.getBufferingHints()))
+				.cloudWatchLoggingOptions(translateCloudWatchLoggingOptions(extendedS3DestinationUpdate.getCloudWatchLoggingOptions()))
+				.compressionFormat(extendedS3DestinationUpdate.getCompressionFormat())
+				.encryptionConfiguration(translateEncryptionConfiguration(extendedS3DestinationUpdate.getEncryptionConfiguration()))
+				.prefix(extendedS3DestinationUpdate.getPrefix())
+				.roleARN(extendedS3DestinationUpdate.getRoleARN())
+				.processingConfiguration(translateProcessingConfiguration(extendedS3DestinationUpdate.getProcessingConfiguration()))
+				.s3BackupMode(extendedS3DestinationUpdate.getS3BackupMode())
+				.s3BackupUpdate(translateS3DestinationUpdate(extendedS3DestinationUpdate.getS3BackupConfiguration()))
+				.errorOutputPrefix(extendedS3DestinationUpdate.getErrorOutputPrefix())
+				.dataFormatConversionConfiguration(translateDataFormatConversionConfiguration(extendedS3DestinationUpdate.getDataFormatConversionConfiguration()))
+				.build();
+	}
+
+	static RedshiftDestinationUpdate translateRedshiftDestinationUpdate(final RedshiftDestinationConfiguration redshiftDestinationConfiguration) {
+		if(redshiftDestinationConfiguration == null) return null;
+		return RedshiftDestinationUpdate.builder()
+				.roleARN(redshiftDestinationConfiguration.getRoleARN())
+				.clusterJDBCURL(redshiftDestinationConfiguration.getClusterJDBCURL())
+				.username(redshiftDestinationConfiguration.getUsername())
+				.password(redshiftDestinationConfiguration.getPassword())
+				.s3Update(translateS3DestinationUpdate(redshiftDestinationConfiguration.getS3Configuration()))
+				.cloudWatchLoggingOptions(translateCloudWatchLoggingOptions(redshiftDestinationConfiguration.getCloudWatchLoggingOptions()))
+				.build();
+	}
+
+	static ElasticsearchDestinationUpdate translateElasticsearchDestinationUpdate(final ElasticsearchDestinationConfiguration elasticsearchDestinationConfiguration) {
+		if(elasticsearchDestinationConfiguration == null) return null;
+		return ElasticsearchDestinationUpdate.builder()
+				.roleARN(elasticsearchDestinationConfiguration.getRoleARN())
+				.domainARN(elasticsearchDestinationConfiguration.getDomainARN())
+				.indexName(elasticsearchDestinationConfiguration.getIndexName())
+				.clusterEndpoint(elasticsearchDestinationConfiguration.getClusterEndpoint())
+				.indexRotationPeriod(elasticsearchDestinationConfiguration.getIndexRotationPeriod())
+				.bufferingHints(translateElasticsearchBufferingHints(elasticsearchDestinationConfiguration.getBufferingHints()))
+				.retryOptions(translateElasticsearchRetryOptions(elasticsearchDestinationConfiguration.getRetryOptions()))
+				.s3Update(translateS3DestinationUpdate(elasticsearchDestinationConfiguration.getS3Configuration()))
+				.cloudWatchLoggingOptions(translateCloudWatchLoggingOptions(elasticsearchDestinationConfiguration.getCloudWatchLoggingOptions()))
+				.build();
+	}
+
+	static SplunkDestinationUpdate translateSplunkDestinationUpdate(final SplunkDestinationConfiguration splunkDestinationConfiguration) {
+		if(splunkDestinationConfiguration == null) return null;
+		return SplunkDestinationUpdate.builder()
+				.cloudWatchLoggingOptions(translateCloudWatchLoggingOptions(splunkDestinationConfiguration.getCloudWatchLoggingOptions()))
+				.hecAcknowledgmentTimeoutInSeconds(splunkDestinationConfiguration.getHECAcknowledgmentTimeoutInSeconds())
+				.hecEndpoint(splunkDestinationConfiguration.getHECEndpoint())
+				.hecEndpointType(splunkDestinationConfiguration.getHECEndpointType())
+				.hecToken(splunkDestinationConfiguration.getHECToken())
+				.processingConfiguration(translateProcessingConfiguration(splunkDestinationConfiguration.getProcessingConfiguration()))
+				.retryOptions(translateSplunkRetryOptions(splunkDestinationConfiguration.getRetryOptions()))
+				.s3BackupMode(splunkDestinationConfiguration.getS3BackupMode())
+				.s3Update(translateS3DestinationUpdate(splunkDestinationConfiguration.getS3Configuration()))
+				.build();
+	}
+}

--- a/deliverystream/src/main/java/com/amazonaws/kinesisfirehose/deliverystream/ListHandler.java
+++ b/deliverystream/src/main/java/com/amazonaws/kinesisfirehose/deliverystream/ListHandler.java
@@ -1,0 +1,30 @@
+package com.amazonaws.kinesisfirehose.deliverystream;
+
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ListHandler extends BaseHandler<CallbackContext> {
+
+    @Override
+    public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext,
+            final Logger logger) {
+
+        final List<ResourceModel> models = new ArrayList<>();
+
+        // TODO : put code here
+
+        return ProgressEvent.<ResourceModel, CallbackContext>builder()
+            .resourceModels(models)
+            .status(OperationStatus.SUCCESS)
+            .build();
+    }
+}

--- a/deliverystream/src/main/java/com/amazonaws/kinesisfirehose/deliverystream/ReadHandler.java
+++ b/deliverystream/src/main/java/com/amazonaws/kinesisfirehose/deliverystream/ReadHandler.java
@@ -1,0 +1,30 @@
+package com.amazonaws.kinesisfirehose.deliverystream;
+
+import lombok.val;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import java.util.Objects;
+
+public class ReadHandler extends BaseHandler<CallbackContext> {
+
+    @Override
+    public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext,
+            final Logger logger) {
+
+        final ResourceModel model = request.getDesiredResourceState();
+
+        // TODO : put code here
+
+        return ProgressEvent.<ResourceModel, CallbackContext>builder()
+                .resourceModel(model)
+                .status(OperationStatus.SUCCESS)
+                .build();
+    }
+}

--- a/deliverystream/src/main/java/com/amazonaws/kinesisfirehose/deliverystream/UpdateHandler.java
+++ b/deliverystream/src/main/java/com/amazonaws/kinesisfirehose/deliverystream/UpdateHandler.java
@@ -1,0 +1,28 @@
+package com.amazonaws.kinesisfirehose.deliverystream;
+
+import lombok.val;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+public class UpdateHandler extends BaseHandler<CallbackContext> {
+
+    @Override
+    public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext,
+            final Logger logger) {
+
+        final ResourceModel model = request.getDesiredResourceState();
+
+        // TODO : put code here
+
+        return ProgressEvent.<ResourceModel, CallbackContext>builder()
+                .resourceModel(model)
+                .status(OperationStatus.SUCCESS)
+                .build();
+    }
+}

--- a/deliverystream/src/test/java/com/amazonaws/kinesisfirehose/deliverystream/CreateHandlerTest.java
+++ b/deliverystream/src/test/java/com/amazonaws/kinesisfirehose/deliverystream/CreateHandlerTest.java
@@ -1,0 +1,400 @@
+package com.amazonaws.kinesisfirehose.deliverystream;
+
+import software.amazon.awssdk.services.firehose.model.CreateDeliveryStreamRequest;
+import software.amazon.awssdk.services.firehose.model.CreateDeliveryStreamResponse;
+import software.amazon.awssdk.services.firehose.model.DeliveryStreamDescription;
+import software.amazon.awssdk.services.firehose.model.DeliveryStreamStatus;
+import software.amazon.awssdk.services.firehose.model.DescribeDeliveryStreamRequest;
+import software.amazon.awssdk.services.firehose.model.DescribeDeliveryStreamResponse;
+import software.amazon.awssdk.services.firehose.model.ResourceInUseException;
+import software.amazon.awssdk.services.firehose.model.ResourceNotFoundException;
+import software.amazon.cloudformation.exceptions.CfnResourceConflictException;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static com.amazonaws.kinesisfirehose.deliverystream.CreateHandler.NUMBER_OF_STATUS_POLL_RETRIES;
+import static com.amazonaws.kinesisfirehose.deliverystream.CreateHandler.TIMED_OUT_MESSAGE;
+import static com.amazonaws.kinesisfirehose.deliverystream.DeliveryStreamTestHelper.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+public class CreateHandlerTest {
+    private CreateHandler handler;
+
+    @Mock
+    private AmazonWebServicesClientProxy proxy;
+
+    @Mock
+    private Logger logger;
+
+    @BeforeEach
+    public void setup() {
+        handler = new CreateHandler();
+    }
+
+    @Test
+    public void testCreateDeliverySteamWithS3ExtendedConfiguration() {
+        final ResourceModel model = ResourceModel.builder()
+                .deliveryStreamName(DELIVERY_STREAM_NAME)
+                .deliveryStreamType(DELIVERY_STREAM_TYPE)
+                .extendedS3DestinationConfiguration(EXTENDED_S3_DESTINATION_CONFIGURATION_FULL)
+                .build();
+
+        final DescribeDeliveryStreamResponse describeResponse = DescribeDeliveryStreamResponse.builder()
+                .deliveryStreamDescription(DeliveryStreamDescription.builder()
+                        .deliveryStreamStatus(DeliveryStreamStatus.CREATING)
+                        .build())
+                .build();
+        final CreateDeliveryStreamResponse createResponse = CreateDeliveryStreamResponse.builder()
+                .deliveryStreamARN(DELIVERY_STREAM_NAME_ARN)
+                .build();
+        when(proxy.injectCredentialsAndInvokeV2(any(DescribeDeliveryStreamRequest.class),
+                any())).thenThrow(ResourceNotFoundException.builder().build())
+                       .thenReturn(describeResponse);
+        when(proxy.injectCredentialsAndInvokeV2(any(CreateDeliveryStreamRequest.class),
+                any())).thenReturn(createResponse);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        final CallbackContext desiredOutputContext = CallbackContext.builder()
+                .stabilizationRetriesRemaining(NUMBER_OF_STATUS_POLL_RETRIES)
+                .deliveryStreamStatus(DeliveryStreamStatus.CREATING.toString())
+                .build();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
+        assertThat(response.getCallbackContext()).isEqualToComparingFieldByField(desiredOutputContext);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(30);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+        verify(proxy, times(1)).injectCredentialsAndInvokeV2(any(CreateDeliveryStreamRequest.class), any());
+    }
+
+    @Test
+    public void testCreateDeliveryStreamWithRedshiftConfiguration() {
+        final ResourceModel model = ResourceModel.builder()
+                .deliveryStreamName(DELIVERY_STREAM_NAME)
+                .deliveryStreamType(DELIVERY_STREAM_TYPE)
+                .redshiftDestinationConfiguration(REDSHIFT_DESTINATION_CONFIGURATION)
+                .build();
+
+        final DescribeDeliveryStreamResponse describeResponse = DescribeDeliveryStreamResponse.builder()
+                .deliveryStreamDescription(DeliveryStreamDescription.builder()
+                        .deliveryStreamStatus(DeliveryStreamStatus.CREATING)
+                        .build())
+                .build();
+        final CreateDeliveryStreamResponse createResponse = CreateDeliveryStreamResponse.builder()
+                .deliveryStreamARN(DELIVERY_STREAM_NAME_ARN)
+                .build();
+        when(proxy.injectCredentialsAndInvokeV2(any(DescribeDeliveryStreamRequest.class),
+                any())).thenThrow(ResourceNotFoundException.builder().build())
+                .thenReturn(describeResponse);
+        when(proxy.injectCredentialsAndInvokeV2(any(CreateDeliveryStreamRequest.class),
+                any())).thenReturn(createResponse);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        final CallbackContext desiredOutputContext = CallbackContext.builder()
+                .stabilizationRetriesRemaining(NUMBER_OF_STATUS_POLL_RETRIES)
+                .deliveryStreamStatus(DeliveryStreamStatus.CREATING.toString())
+                .build();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
+        assertThat(response.getCallbackContext()).isEqualToComparingFieldByField(desiredOutputContext);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(30);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+        verify(proxy, times(1)).injectCredentialsAndInvokeV2(any(CreateDeliveryStreamRequest.class), any());
+    }
+
+    @Test
+    public void testCreateDeliveryStreamWithElasticSearchConfiguration() {
+        final ResourceModel model = ResourceModel.builder()
+                .deliveryStreamName(DELIVERY_STREAM_NAME)
+                .deliveryStreamType(DELIVERY_STREAM_TYPE)
+                .elasticsearchDestinationConfiguration(ELASTICSEARCH_DESTINATION_CONFIGURATION_FULL)
+                .build();
+
+        final DescribeDeliveryStreamResponse describeResponse = DescribeDeliveryStreamResponse.builder()
+                .deliveryStreamDescription(DeliveryStreamDescription.builder()
+                        .deliveryStreamStatus(DeliveryStreamStatus.CREATING)
+                        .build())
+                .build();
+        final CreateDeliveryStreamResponse createResponse = CreateDeliveryStreamResponse.builder()
+                .deliveryStreamARN(DELIVERY_STREAM_NAME_ARN)
+                .build();
+        when(proxy.injectCredentialsAndInvokeV2(any(DescribeDeliveryStreamRequest.class),
+                any())).thenThrow(ResourceNotFoundException.builder().build())
+                .thenReturn(describeResponse);
+        when(proxy.injectCredentialsAndInvokeV2(any(CreateDeliveryStreamRequest.class),
+                any())).thenReturn(createResponse);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        final CallbackContext desiredOutputContext = CallbackContext.builder()
+                .stabilizationRetriesRemaining(NUMBER_OF_STATUS_POLL_RETRIES)
+                .deliveryStreamStatus(DeliveryStreamStatus.CREATING.toString())
+                .build();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
+        assertThat(response.getCallbackContext()).isEqualToComparingFieldByField(desiredOutputContext);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(30);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+        verify(proxy, times(1)).injectCredentialsAndInvokeV2(any(CreateDeliveryStreamRequest.class), any());
+    }
+
+    @Test
+    public void testCreateDeliveryStreamWithSplunkConfiguration() {
+        final ResourceModel model = ResourceModel.builder()
+                .deliveryStreamName(DELIVERY_STREAM_NAME)
+                .deliveryStreamType(DELIVERY_STREAM_TYPE)
+                .splunkDestinationConfiguration(SPLUNK_CONFIGURATION_FULL)
+                .build();
+
+        final DescribeDeliveryStreamResponse describeResponse = DescribeDeliveryStreamResponse.builder()
+                .deliveryStreamDescription(DeliveryStreamDescription.builder()
+                        .deliveryStreamStatus(DeliveryStreamStatus.CREATING)
+                        .build())
+                .build();
+        final CreateDeliveryStreamResponse createResponse = CreateDeliveryStreamResponse.builder()
+                .deliveryStreamARN(DELIVERY_STREAM_NAME_ARN)
+                .build();
+        when(proxy.injectCredentialsAndInvokeV2(any(DescribeDeliveryStreamRequest.class),
+                any())).thenThrow(ResourceNotFoundException.builder().build())
+                .thenReturn(describeResponse);
+        when(proxy.injectCredentialsAndInvokeV2(any(CreateDeliveryStreamRequest.class),
+                any())).thenReturn(createResponse);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        final CallbackContext desiredOutputContext = CallbackContext.builder()
+                .stabilizationRetriesRemaining(NUMBER_OF_STATUS_POLL_RETRIES)
+                .deliveryStreamStatus(DeliveryStreamStatus.CREATING.toString())
+                .build();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
+        assertThat(response.getCallbackContext()).isEqualToComparingFieldByField(desiredOutputContext);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(30);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+        verify(proxy, times(1)).injectCredentialsAndInvokeV2(any(CreateDeliveryStreamRequest.class), any());
+    }
+
+    @Test
+    public void testCreateDeliveryStreamWithSASConfiguration() {
+        final ResourceModel model = ResourceModel.builder()
+                .deliveryStreamName(DELIVERY_STREAM_NAME)
+                .deliveryStreamType(DELIVERY_STREAM_TYPE)
+                .extendedS3DestinationConfiguration(EXTENDED_S3_DESTINATION_CONFIGURATION_FULL)
+                .kinesisStreamSourceConfiguration(KINESIS_STREAM_SOURCE_CONFIGURATION)
+                .build();
+
+        final DescribeDeliveryStreamResponse describeResponse = DescribeDeliveryStreamResponse.builder()
+                .deliveryStreamDescription(DeliveryStreamDescription.builder()
+                        .deliveryStreamStatus(DeliveryStreamStatus.CREATING)
+                        .build())
+                .build();
+        final CreateDeliveryStreamResponse createResponse = CreateDeliveryStreamResponse.builder()
+                .deliveryStreamARN(DELIVERY_STREAM_NAME_ARN)
+                .build();
+        when(proxy.injectCredentialsAndInvokeV2(any(DescribeDeliveryStreamRequest.class),
+                any())).thenThrow(ResourceNotFoundException.builder().build())
+                .thenReturn(describeResponse);
+        when(proxy.injectCredentialsAndInvokeV2(any(CreateDeliveryStreamRequest.class),
+                any())).thenReturn(createResponse);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        final CallbackContext desiredOutputContext = CallbackContext.builder()
+                .stabilizationRetriesRemaining(NUMBER_OF_STATUS_POLL_RETRIES)
+                .deliveryStreamStatus(DeliveryStreamStatus.CREATING.toString())
+                .build();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
+        assertThat(response.getCallbackContext()).isEqualToComparingFieldByField(desiredOutputContext);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(30);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+        verify(proxy, times(1)).injectCredentialsAndInvokeV2(any(CreateDeliveryStreamRequest.class), any());
+    }
+
+    @Test
+    public void testCreateDeliverySteamInProgress() {
+        final ResourceModel model = ResourceModel.builder()
+                .deliveryStreamName(DELIVERY_STREAM_NAME)
+                .deliveryStreamType(DELIVERY_STREAM_TYPE)
+                .extendedS3DestinationConfiguration(EXTENDED_S3_DESTINATION_CONFIGURATION_FULL)
+                .build();
+
+        final DescribeDeliveryStreamResponse describeResponse = DescribeDeliveryStreamResponse.builder()
+                .deliveryStreamDescription(DeliveryStreamDescription.builder()
+                        .deliveryStreamStatus(DeliveryStreamStatus.CREATING)
+                        .build())
+                .build();
+
+        when(proxy.injectCredentialsAndInvokeV2(any(DescribeDeliveryStreamRequest.class), any()))
+                .thenReturn(describeResponse);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final CallbackContext context = CallbackContext.builder()
+                .stabilizationRetriesRemaining(NUMBER_OF_STATUS_POLL_RETRIES)
+                .deliveryStreamStatus(DeliveryStreamStatus.CREATING.toString())
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, context, logger);
+
+        final CallbackContext desiredOutputContext = CallbackContext.builder()
+                .stabilizationRetriesRemaining(NUMBER_OF_STATUS_POLL_RETRIES-1)
+                .deliveryStreamStatus(DeliveryStreamStatus.CREATING.toString())
+                .build();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
+        assertThat(response.getCallbackContext()).isEqualToComparingFieldByField(desiredOutputContext);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(30);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+        verify(proxy, times(0)).injectCredentialsAndInvokeV2(any(CreateDeliveryStreamRequest.class), any());
+    }
+
+    @Test
+    public void testCreateDeliverySteamComplete() {
+        final ResourceModel model = ResourceModel.builder()
+                .deliveryStreamName(DELIVERY_STREAM_NAME)
+                .deliveryStreamType(DELIVERY_STREAM_TYPE)
+                .extendedS3DestinationConfiguration(EXTENDED_S3_DESTINATION_CONFIGURATION_FULL)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final CallbackContext context = CallbackContext.builder()
+                .stabilizationRetriesRemaining(NUMBER_OF_STATUS_POLL_RETRIES-1)
+                .deliveryStreamStatus(DeliveryStreamStatus.ACTIVE.toString())
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, context, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+        verify(proxy, times(0)).injectCredentialsAndInvokeV2(any(CreateDeliveryStreamRequest.class), any());
+    }
+
+
+    @Test
+    public void testCreateDeliverySteamStabilizationTimeout() {
+        final ResourceModel model = ResourceModel.builder()
+                .deliveryStreamName(DELIVERY_STREAM_NAME)
+                .deliveryStreamType(DELIVERY_STREAM_TYPE)
+                .extendedS3DestinationConfiguration(EXTENDED_S3_DESTINATION_CONFIGURATION_FULL)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final CallbackContext context = CallbackContext.builder()
+                .stabilizationRetriesRemaining(0)
+                .deliveryStreamStatus(DeliveryStreamStatus.CREATING.toString())
+                .build();
+
+        try {
+            handler.handleRequest(proxy, request, context, logger);
+        } catch (RuntimeException e) {
+            assertThat(e.getMessage()).isEqualTo(TIMED_OUT_MESSAGE);
+        }
+    }
+
+    @Test
+    public void testCreateDeliverySteamAlreadyExists() {
+        final ResourceModel model = ResourceModel.builder()
+                .deliveryStreamName(DELIVERY_STREAM_NAME)
+                .deliveryStreamType(DELIVERY_STREAM_TYPE)
+                .extendedS3DestinationConfiguration(EXTENDED_S3_DESTINATION_CONFIGURATION_FULL)
+                .build();
+
+        final DescribeDeliveryStreamResponse describeResponse = DescribeDeliveryStreamResponse.builder()
+                .deliveryStreamDescription(DeliveryStreamDescription.builder()
+                        .deliveryStreamStatus(DeliveryStreamStatus.CREATING)
+                        .build())
+                .build();
+
+        when(proxy.injectCredentialsAndInvokeV2(any(DescribeDeliveryStreamRequest.class),
+                any())).thenReturn(describeResponse);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        try {
+            handler.handleRequest(proxy, request, null, logger);
+        } catch (CfnResourceConflictException e) {
+            assertThat(e.getCause()).isInstanceOf(ResourceInUseException.class);
+            verify(proxy, times(0)).injectCredentialsAndInvokeV2(any(CreateDeliveryStreamRequest.class), any());
+        }
+    }
+}

--- a/deliverystream/src/test/java/com/amazonaws/kinesisfirehose/deliverystream/DeleteHandlerTest.java
+++ b/deliverystream/src/test/java/com/amazonaws/kinesisfirehose/deliverystream/DeleteHandlerTest.java
@@ -1,0 +1,31 @@
+package com.amazonaws.kinesisfirehose.deliverystream;
+
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+public class DeleteHandlerTest {
+
+    @Mock
+    private AmazonWebServicesClientProxy proxy;
+
+    @Mock
+    private Logger logger;
+
+    @BeforeEach
+    public void setup() {
+        proxy = mock(AmazonWebServicesClientProxy.class);
+        logger = mock(Logger.class);
+    }
+}

--- a/deliverystream/src/test/java/com/amazonaws/kinesisfirehose/deliverystream/DeliveryStreamTestHelper.java
+++ b/deliverystream/src/test/java/com/amazonaws/kinesisfirehose/deliverystream/DeliveryStreamTestHelper.java
@@ -1,0 +1,96 @@
+package com.amazonaws.kinesisfirehose.deliverystream;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Collections;
+
+public class DeliveryStreamTestHelper  {
+    public static final int INTERVAL_IN_SECONDS = 120;
+    public static final int SIZE_IN_MBS = 100;
+    public static final int INTERVAL_IN_SECONDS_UPDATED = 60;
+    public static final int SIZE_IN_MBS_UPDATED = 200;
+    public static final BufferingHints BUFFERING_HINTS = new BufferingHints(SIZE_IN_MBS, INTERVAL_IN_SECONDS);
+    public static final BufferingHints BUFFERING_HINTS_UPDATED = new BufferingHints(SIZE_IN_MBS_UPDATED, INTERVAL_IN_SECONDS_UPDATED);
+    public static final String COMPRESSION_FORMAT = "UNCOMPRESSED";
+    public static final String COMPRESSION_FORMAT_UPDATED = "GZIP";
+    public static final String PREFIX = "prefix/";
+    public static final String PREFIX_UPDATED = "prefix_updated/";
+    public static final String ROLE_ARN = "ROLE_ARN";
+    public static final String ROLE_ARN_UPDATED = "ROLE_ARN_UPDATED";
+    public static final String BUCKET_ARN = "BUCKET_ARN";
+    public static final String BUCKET_ARN_UPDATED = "BUCKET_ARN_UPDATED";
+    public static final String BACKUP_MODE = "BackupMode";
+    public static final String KMS_KEY_ARN = "Arn";
+    public static final String NO_ENCRYPTION_CONFIG = "NoEncryptionConfig";
+    public static final String ERROR_OUTPUT_PREFIX = "error_output_prefix";
+    public static final String ERROR_OUTPUT_PREFIX_UPDATE = "error_output_prefix_update";
+    public static final KMSEncryptionConfig KMS_ENCRYPTION_CONFIG = new KMSEncryptionConfig(KMS_KEY_ARN);
+    public static final EncryptionConfiguration ENCRYPTION_CONFIGURATION = new EncryptionConfiguration(KMS_ENCRYPTION_CONFIG, NO_ENCRYPTION_CONFIG);
+    public static final S3DestinationConfiguration S3_DESTINATION_CONFIG = new S3DestinationConfiguration(BUCKET_ARN, BUFFERING_HINTS, null, COMPRESSION_FORMAT, null, PREFIX, ROLE_ARN, ERROR_OUTPUT_PREFIX);
+    public static final S3DestinationConfiguration S3_DESTINATION_CONFIG_UPDATED = new S3DestinationConfiguration(BUCKET_ARN_UPDATED, BUFFERING_HINTS_UPDATED, null, COMPRESSION_FORMAT_UPDATED, null, PREFIX_UPDATED, ROLE_ARN_UPDATED, ERROR_OUTPUT_PREFIX_UPDATE);
+    public static final String DELIVERY_STREAM_NAME = "streamname";
+    public static final String DELIVERY_STREAM_NAME_UPDATED = "streamname_update";
+    public static final String DELIVERY_STREAM_NAME_ARN = "arn:aws:firehose:us-east-1:900582091538:deliverystream/" + DELIVERY_STREAM_NAME;
+    public static final String DELIVERY_STREAM_NAME_ARN_UPDATED = "arn:aws:firehose:us-east-1:900582091538:deliverystream/" + DELIVERY_STREAM_NAME_UPDATED;
+    public static final String DELIVERY_STREAM_TYPE = "streamType";
+    public static final String DELIVERY_STREAM_TYPE_UPDATED = "streamTypeUpdated";
+
+    public static final ResourceModel RESOURCE_UNNAMED = new ResourceModel(null, null, null, null, null, null,  null, null, S3_DESTINATION_CONFIG, null);
+    public static final ResourceModel RESOURCE = new ResourceModel(DELIVERY_STREAM_NAME, null, DELIVERY_STREAM_NAME, null, null, null, null, null, S3_DESTINATION_CONFIG, null);
+    public static final ResourceModel RESOURCE_UPDATED = new ResourceModel(DELIVERY_STREAM_NAME, null, DELIVERY_STREAM_NAME, null, null, null, null, null,  S3_DESTINATION_CONFIG_UPDATED, null);
+
+    public static final CloudWatchLoggingOptions CLOUD_WATCH_LOGGING_OPTIONS = new CloudWatchLoggingOptions(true, "LogGroupName", "LogStreamName");
+    public static final ProcessingConfiguration PROCESSING_CONFIGURATION = new ProcessingConfiguration(true, Collections.emptyList());
+    public static final SplunkRetryOptions RETRY_OPTIONS = new SplunkRetryOptions(INTERVAL_IN_SECONDS);
+    public static final SplunkDestinationConfiguration SPLUNK_CONFIGURATION_FULL = new SplunkDestinationConfiguration(CLOUD_WATCH_LOGGING_OPTIONS, 60, "endpoint", "type", "token", PROCESSING_CONFIGURATION, RETRY_OPTIONS, "backup", S3_DESTINATION_CONFIG);
+    public static final ResourceModel RESOURCE_WITH_SPLUNK = new ResourceModel(null, null, null, null, null, null, null, null, null, SPLUNK_CONFIGURATION_FULL);
+
+    public static final DataFormatConversionConfiguration DATA_FORMAT_CONVERSION_CONFIGURATION = DataFormatConversionConfiguration.builder()
+            .inputFormatConfiguration(InputFormatConfiguration.builder()
+                    .deserializer(Deserializer.builder()
+                            .openXJsonSerDe(OpenXJsonSerDe.builder()
+                                    .caseInsensitive(true)
+                                    .convertDotsInJsonKeysToUnderscores(false)
+                                    .columnToJsonKeyMappings(ImmutableMap.of())
+                                    .build())
+                            .build())
+                    .build())
+            .outputFormatConfiguration(OutputFormatConfiguration.builder()
+                    .serializer(Serializer.builder()
+                            .parquetSerDe(ParquetSerDe.builder()
+                                    .build())
+                            .build())
+                    .build())
+            .schemaConfiguration(SchemaConfiguration.builder()
+                    .databaseName("SAMPLEDATABASE")
+                    .tableName("SAMPLETABLE")
+                    .region("us-east-1")
+                    .roleARN("SAMPLEROLE")
+                    .catalogId("900582091538")
+                    .versionId("0")
+                    .build())
+            .enabled(true)
+            .build();
+
+    public static final S3DestinationConfiguration S3_DESTINATION_CONFIG_FULL = new S3DestinationConfiguration(BUCKET_ARN, BUFFERING_HINTS, CLOUD_WATCH_LOGGING_OPTIONS, COMPRESSION_FORMAT, ENCRYPTION_CONFIGURATION, PREFIX, ROLE_ARN, ERROR_OUTPUT_PREFIX);
+    public static final ExtendedS3DestinationConfiguration EXTENDED_S3_DESTINATION_CONFIGURATION_FULL = new ExtendedS3DestinationConfiguration(BUCKET_ARN, BUFFERING_HINTS, CLOUD_WATCH_LOGGING_OPTIONS, COMPRESSION_FORMAT, DATA_FORMAT_CONVERSION_CONFIGURATION, ENCRYPTION_CONFIGURATION, ERROR_OUTPUT_PREFIX, PREFIX , PROCESSING_CONFIGURATION, ROLE_ARN, S3_DESTINATION_CONFIG_FULL, BACKUP_MODE);
+    public static final ResourceModel RESOURCE_WITH_S3_EXTENDED = new ResourceModel(DELIVERY_STREAM_NAME, DELIVERY_STREAM_NAME_ARN, DELIVERY_STREAM_NAME, DELIVERY_STREAM_TYPE, null, EXTENDED_S3_DESTINATION_CONFIGURATION_FULL, null, null, null,  null);
+
+
+    public static final String DOMAIN_ARN = "DomainArn";
+    public static final String INDEX_NAME = "IndexName";
+    public static final String INDEX_ROTATION_PERIOD = "RotationPeriod";
+    public static final String TYPE_NAME = "TypeName";
+    public static final int DURATION_IN_SECONDS = 120;
+    public static final ElasticsearchRetryOptions ELASTICSEARCH_RETRY_OPTIONS = new ElasticsearchRetryOptions(DURATION_IN_SECONDS);
+    public static final ElasticsearchBufferingHints ELASTICSEARCH_BUFFERING_HINTS = new ElasticsearchBufferingHints(INTERVAL_IN_SECONDS, SIZE_IN_MBS);
+    public static final ElasticsearchDestinationConfiguration ELASTICSEARCH_DESTINATION_CONFIGURATION_FULL = new ElasticsearchDestinationConfiguration(ELASTICSEARCH_BUFFERING_HINTS, CLOUD_WATCH_LOGGING_OPTIONS, DOMAIN_ARN, INDEX_NAME, INDEX_ROTATION_PERIOD, PROCESSING_CONFIGURATION, ELASTICSEARCH_RETRY_OPTIONS, ROLE_ARN, BACKUP_MODE, S3_DESTINATION_CONFIG_FULL, TYPE_NAME);
+    public static final ResourceModel RESOURCE_WITH_ELASTICSEARCH = new ResourceModel(DELIVERY_STREAM_NAME, DELIVERY_STREAM_NAME_ARN, DELIVERY_STREAM_NAME, DELIVERY_STREAM_TYPE, ELASTICSEARCH_DESTINATION_CONFIGURATION_FULL,null, null, null, null,  null);
+
+    public static final String KINESIS_STREAM_ARN = "KinesisStreamArn";
+    public static final KinesisStreamSourceConfiguration KINESIS_STREAM_SOURCE_CONFIGURATION = new KinesisStreamSourceConfiguration(KINESIS_STREAM_ARN, ROLE_ARN);
+    public static final ResourceModel RESOURCE_WITH_KINESIS = new ResourceModel(DELIVERY_STREAM_NAME, DELIVERY_STREAM_NAME_ARN, DELIVERY_STREAM_NAME, DELIVERY_STREAM_TYPE, null, EXTENDED_S3_DESTINATION_CONFIGURATION_FULL, KINESIS_STREAM_SOURCE_CONFIGURATION, null,  null, null);
+
+    public static final RedshiftDestinationConfiguration REDSHIFT_DESTINATION_CONFIGURATION = new RedshiftDestinationConfiguration(CLOUD_WATCH_LOGGING_OPTIONS, "ClusterJBDCurl", new CopyCommand("CopyOptions", "DataTableColumns", "DataTableName"), "Password", PROCESSING_CONFIGURATION, ROLE_ARN, S3_DESTINATION_CONFIG_FULL, "Username");
+    public static final ResourceModel RESOURCE_WITH_REDSHIFT = new ResourceModel(DELIVERY_STREAM_NAME, DELIVERY_STREAM_NAME_ARN, DELIVERY_STREAM_NAME, DELIVERY_STREAM_TYPE, null, null, null, REDSHIFT_DESTINATION_CONFIGURATION, null,  null);
+}

--- a/deliverystream/src/test/java/com/amazonaws/kinesisfirehose/deliverystream/ListHandlerTest.java
+++ b/deliverystream/src/test/java/com/amazonaws/kinesisfirehose/deliverystream/ListHandlerTest.java
@@ -1,0 +1,31 @@
+package com.amazonaws.kinesisfirehose.deliverystream;
+
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+public class ListHandlerTest {
+
+    @Mock
+    private AmazonWebServicesClientProxy proxy;
+
+    @Mock
+    private Logger logger;
+
+    @BeforeEach
+    public void setup() {
+        proxy = mock(AmazonWebServicesClientProxy.class);
+        logger = mock(Logger.class);
+    }
+}

--- a/deliverystream/src/test/java/com/amazonaws/kinesisfirehose/deliverystream/ReadHandlerTest.java
+++ b/deliverystream/src/test/java/com/amazonaws/kinesisfirehose/deliverystream/ReadHandlerTest.java
@@ -1,0 +1,31 @@
+package com.amazonaws.kinesisfirehose.deliverystream;
+
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+public class ReadHandlerTest {
+
+    @Mock
+    private AmazonWebServicesClientProxy proxy;
+
+    @Mock
+    private Logger logger;
+
+    @BeforeEach
+    public void setup() {
+        proxy = mock(AmazonWebServicesClientProxy.class);
+        logger = mock(Logger.class);
+    }
+}

--- a/deliverystream/src/test/java/com/amazonaws/kinesisfirehose/deliverystream/UpdateHandlerTest.java
+++ b/deliverystream/src/test/java/com/amazonaws/kinesisfirehose/deliverystream/UpdateHandlerTest.java
@@ -1,0 +1,31 @@
+package com.amazonaws.kinesisfirehose.deliverystream;
+
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+public class UpdateHandlerTest {
+
+    @Mock
+    private AmazonWebServicesClientProxy proxy;
+
+    @Mock
+    private Logger logger;
+
+    @BeforeEach
+    public void setup() {
+        proxy = mock(AmazonWebServicesClientProxy.class);
+        logger = mock(Logger.class);
+    }
+}


### PR DESCRIPTION
Add Handler for Create and corresponding UTs

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.amazonaws.kinesisfirehose.deliverystream.CreateHandlerTest
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.394 s - in com.amazonaws.kinesisfirehose.deliverystream.CreateHandlerTest
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO]
[INFO] --- jacoco-maven-plugin:0.8.4:report (report) @ aws-kinesisfirehose-deliverystream-handler ---
[INFO] Loading execution data file /Volumes/Unix/workplace/commituluru_g/aws-cloudformation-resource-providers-kinesisfirehose/deliverystream/target/jacoco.exec
[INFO] Analyzed bundle 'aws-kinesisfirehose-deliverystream-handler' with 35 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  13.138 s
[INFO] Finished at: 2020-03-19T12:04:41-07:00
[INFO] ------------------------------------------------------------------------
```
