### PR TITLE
Add TypeName as one of the attributes for ES Destination for versions 6.x or less

### DIFF
--- a/deliverystream/aws-kinesisfirehose-deliverystream.json
+++ b/deliverystream/aws-kinesisfirehose-deliverystream.json
@@ -244,6 +244,9 @@
         },
         "ClusterEndpoint": {
           "type": "string"
+        },
+        "TypeName": {
+          "type": "string"
         }
       },
       "required": [


### PR DESCRIPTION
*Issue #, if available:*
https://issues.amazon.com/issues/FH-7222

*Description of changes:*
TypeName is needed for ES Destination for ES clusters which have versions 6.x or less.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
